### PR TITLE
Update Benimator to v2.0 to support Bevy v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 bevy = "0.6"
 asefile = { git = "https://github.com/B-Reif/asefile", branch = "main" }
 anyhow = "1.0"
-benimator = { version = "0.3.0", optional = true }
+benimator = { version = "2.0", optional = true }
 bevy_ecs_tilemap = { version = "0.5", optional = true }
 
 [profile.dev.package."*"]

--- a/examples/animated/main.rs
+++ b/examples/animated/main.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use bevy::{input::system::exit_on_esc_system, prelude::*, sprite::entity::SpriteSheetBundle};
+use bevy::{input::system::exit_on_esc_system, prelude::*, sprite::SpriteSheetBundle};
 use bevy_ase::{
     self,
     asset::{Animation, AseAsset},
@@ -8,10 +8,10 @@ use bevy_ase::{
 };
 
 fn main() {
-    App::build()
+    App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(loader::AseLoaderDefaultPlugin)
-        .add_plugin(benimator::AnimationPlugin)
+        .add_plugin(benimator::AnimationPlugin::default())
         .add_system(exit_on_esc_system.system())
         .add_state(AppState::Loading)
         .add_system_set(SystemSet::on_enter(AppState::Loading).with_system(load_sprites.system()))

--- a/src/benimator.rs
+++ b/src/benimator.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 
 impl From<&Frame> for benimator::Frame {
     fn from(f: &Frame) -> Self {
-        benimator::Frame {
-            duration: Duration::from_millis(f.duration_ms as u64),
-            index: f.sprite.atlas_index,
-        }
+        benimator::Frame::new(
+            f.sprite.atlas_index as usize,
+            Duration::from_millis(f.duration_ms as u64),
+        )
     }
 }
 impl From<&Animation> for benimator::SpriteSheetAnimation {


### PR DESCRIPTION
Benimator v0.3.1 used Bevy 0.5, which meant that enabling the `benimator` feature would bring in two incompatible versions of Bevy. This PR updates the Benimator dependency to the latest version (v2.0.x) to fix that.